### PR TITLE
Fix cleanup /  search / results order + CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+test/vendor/**
+test/.bundle
+mkmf.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+---
+language: ruby
+dist: xenial
+addons:
+  apt:
+    sources:
+      - sourceline: "ppa:kimura-o/ppa-tmux"
+    packages:
+      - tmux
+stages:
+  - name: tests
+  - name: mkrelease
+    if: |
+      branch = master \
+      AND type != pull_request
+jobs:
+  include:
+    - stage: tests
+      rvm: "2.5"
+      install:
+        - git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
+        - ~/.fzf/install --no-key-bindings --no-completion --update-rc
+        - source ~/.bashrc
+        - cd test
+        - gem install bundler -v $(cat Gemfile.lock | grep -A 1 "BUNDLED WITH" | tail -n1 | sed "s/ //g")
+        - bundle
+      script:
+        - bundle exec ruby test-fzf-obc.rb
+
+    - stage: mkrelease
+      install:
+        - wget --quiet -O /tmp/mkrelease.sh https://raw.githubusercontent.com/rockandska/scripts/${MKRELEASE_REF:-master}/CI/mkrelease.sh
+        - chmod +x /tmp/mkrelease.sh
+        - wget --quiet -O /tmp/pubrelease.sh https://raw.githubusercontent.com/rockandska/scripts/${PUBRELEASE_REF:-master}/CI/pubrelease.sh
+        - chmod +x /tmp/pubrelease.sh
+      script:
+        - TRAVIS_TAG=$(/tmp/mkrelease.sh || travis_terminate 1)
+        - export TRAVIS_TAG
+      deploy:
+        provider: script
+        script: /tmp/pubrelease.sh
+        skip_cleanup: true
+        on:
+          tags: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What is fzf-obc
 
-A bash completion script intend to add [fzf](https://github.com/junegunn/fzf) over all known bash completion functions on your system without minimal modifications on original completion scripts.  
+A bash completion script intend to add [fzf](https://github.com/junegunn/fzf) over all known bash completion functions on your system with minimal modifications on original completion scripts.  
 It is a replacement to the completion script natively provided by [fzf](https://github.com/junegunn/fzf) who replace original completion functions with its own (and create some behavior originally well implemented into original completion scripts).
 
 ## Prerequisites
@@ -174,6 +174,8 @@ $ echo "FZF_OBC_PATH='~/.local/opt/myfzfcomplete:~/.local/opt/fzf-test'" >> ~/.b
   - use `$FZF_OBC_GLOBS_OPTIONS` if `**` detected in `$cur`
 - `__fzf_obc_post__kill`
   - post function to `_kill`
+- `__fzf_obc_sort_cmd`
+  - sort command used to sort results from `compgen` / `find` results
 - `__fzf_obc_trap__filedir`
   - trap for `_filedir` private complete function
   - add `/` to directories

--- a/bash_completion.d/_completion_loader
+++ b/bash_completion.d/_completion_loader
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 __fzf_obc_post__completion_loader() {
   __fzf_obc_update_complete || return $?
 }

--- a/bash_completion.d/_filedir
+++ b/bash_completion.d/_filedir
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 __fzf_obc_trap__filedir()
 {
   local last_status=$1
@@ -7,7 +8,7 @@ __fzf_obc_trap__filedir()
   # Exclude from COMPREPLY directories listed into FZF_OBC_EXCLUDE_PATH
   local i reply_expand exclude_arr exclude exclude_expand
   IFS=':' read -r -a exclude_arr <<< "${FZF_OBC_EXCLUDE_PATH}"
-  for i in ${!COMPREPLY[@]};do
+  for i in "${!COMPREPLY[@]}";do
     reply_expand="${COMPREPLY[$i]}"
     __fzf_obc_expand_tilde_by_ref reply_expand
     for exclude in "${exclude_arr[@]}";do
@@ -42,4 +43,5 @@ __fzf_obc_trap__filedir()
     fi
     cur="${cur}**"
   fi
+  return "${last_status}"
 }

--- a/bash_completion.d/_fzf_obc_functions
+++ b/bash_completion.d/_fzf_obc_functions
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# sort cmd used to show results
+__fzf_obc_sort_cmd() {
+    (LC_ALL=C sort -ufr -S 50% --parallel="$( awk '/^processor/{print $3}' < /proc/cpuinfo | wc -l)" 2> /dev/null || LC_ALL=C sort -ufr)
+}
+
 # get find exclude pattern
 __fzf_obc_globs_exclude() {
   local var=$1
@@ -108,8 +113,8 @@ __fzf_obc_read_compreply() {
       compopt +o filenames
       read -r -a COMPREPLY < <(
         printf "%s\n" "${COMPREPLY[@]}" \
-        | awk '! a[$0]++' \
-        | FZF_DEFAULT_OPTS="--height ${FZF_OBC_HEIGHT} --reverse ${FZF_OBC_GLOBS_OPTS} ${FZF_OBC_GLOBS_BINDINGS}" \
+        | __fzf_obc_sort_cmd \
+        | FZF_DEFAULT_OPTS="--reverse --height ${FZF_OBC_HEIGHT} ${FZF_OBC_GLOBS_OPTS} ${FZF_OBC_GLOBS_BINDINGS}" \
           __fzf_obc_cmd \
         | while read -r item;do printf "%q " "${item}" | sed 's/^\\~/~/';done \
         | sed 's/ $//'
@@ -117,8 +122,8 @@ __fzf_obc_read_compreply() {
     else
       read -r -a COMPREPLY < <(
         printf "%s\n" "${COMPREPLY[@]}" \
-        | awk '! a[$0]++' \
-        | FZF_DEFAULT_OPTS="--height ${FZF_OBC_HEIGHT} --reverse ${FZF_OBC_OPTS} ${FZF_OBC_BINDINGS}" \
+        | __fzf_obc_sort_cmd \
+        | FZF_DEFAULT_OPTS="--reverse --height ${FZF_OBC_HEIGHT} ${FZF_OBC_OPTS} ${FZF_OBC_BINDINGS}" \
           __fzf_obc_cmd
       )
     fi

--- a/bash_completion.d/_fzf_obc_functions
+++ b/bash_completion.d/_fzf_obc_functions
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # get find exclude pattern
 __fzf_obc_globs_exclude() {
   local var=$1
@@ -66,9 +67,11 @@ __fzf_obc_search() {
 
 __fzf_obc_expand_tilde_by_ref ()
 {
+  local expand
   # Copy from original bash complete
   if [[ ${!1} == \~* ]]; then
-      eval $1=$(printf ~%q "${!1#\~}");
+    read -r -d '' expand < <(printf ~%q "${!1#\~}")
+    eval "$1"="${expand}";
   fi
 }
 
@@ -81,21 +84,20 @@ __fzf_obc_tilde ()
       result=${#COMPREPLY[@]};
       [[ $result -gt 0 ]] && compopt -o filenames 2> /dev/null;
   fi;
-  return $result
+  return "${result}"
 }
 
 __fzf_obc_cmd() {
-    fzf $@
+    fzf
 }
 
 __fzf_obc_read_compreply() {
   local IFS=$'\n'
-  local status=$1
   if [[ "${#COMPREPLY[@]}" -ne 0 ]];then
     if [[ "${cur}" == *"**" ]];then
       local item
       compopt +o filenames
-      read -r -a COMPREPLY <<<$(
+      read -r -a COMPREPLY < <(
         printf "%s\n" "${COMPREPLY[@]}" \
         | awk '! a[$0]++' \
         | FZF_DEFAULT_OPTS="--height ${FZF_OBC_HEIGHT} --reverse ${FZF_OBC_GLOBS_OPTS} ${FZF_OBC_GLOBS_BINDINGS}" \
@@ -104,7 +106,7 @@ __fzf_obc_read_compreply() {
         | sed 's/ $//'
       )
     else
-      read -r -a COMPREPLY <<<$(
+      read -r -a COMPREPLY < <(
         printf "%s\n" "${COMPREPLY[@]}" \
         | awk '! a[$0]++' \
         | FZF_DEFAULT_OPTS="--height ${FZF_OBC_HEIGHT} --reverse ${FZF_OBC_OPTS} ${FZF_OBC_BINDINGS}" \
@@ -118,6 +120,5 @@ __fzf_obc_read_compreply() {
       COMPREPLY=( "${cur%\*\*}" )
     fi
   fi
-  return ${status}
 }
 

--- a/bash_completion.d/_fzf_obc_functions
+++ b/bash_completion.d/_fzf_obc_functions
@@ -37,13 +37,13 @@ __fzf_obc_search() {
   if [[ -n "${cur_expanded}" ]] && [[ ! "${cur_expanded}" =~ (\.\.?|/)$ ]];then
     startdir="${cur_expanded}*"
   else
-    startdir="${cur_expanded}"
+    startdir="${cur_expanded} -mindepth 1"
   fi
 
   local exclude_string
   __fzf_obc_globs_exclude exclude_string
 
-  cmd="command find -L $startdir -mindepth 1 -maxdepth '${FZF_OBC_GLOBS_MAXDEPTH}' ${exclude_string}"
+  cmd="command find -L $startdir -maxdepth '${FZF_OBC_GLOBS_MAXDEPTH}' ${exclude_string}"
 
   case ${type} in
     paths)
@@ -58,9 +58,18 @@ __fzf_obc_search() {
   esac
 
   if [[ "${type}" == "files" ]] && [[ -n ${xspec} ]];then
-    cmd+=" -exec bash -c 'shopt -s extglob; for file;do [[ \"\$file\" == ${xspec} ]] && echo \"\${file/${cur_expanded//\//\\/}/${cur//\//\\/}}\";done' internalsh {} + 2> /dev/null"
+    cmd+=" -exec bash -c 'shopt -s extglob; for file;do [[ \"\$file\" == ${xspec} ]]"
+    if [[ "${cur_expanded}" != "${cur}" ]];then
+      cmd+=" && echo \"\${file/${cur_expanded//\//\\/}/${cur//\//\\/}}\""
+    else
+      cmd+=" && echo \"\${file}\""
+    fi
+    cmd+=";done' internalsh {} + 2> /dev/null"
   else
-    cmd+=" 2> /dev/null | sed 's/${cur_expanded//\//\\/}/${cur//\//\\/}/'"
+    cmd+=" 2> /dev/null"
+    if [[ "${cur_expanded}" != "${cur}" ]];then
+      cmd+=" | sed 's/${cur_expanded//\//\\/}/${cur//\//\\/}/'"
+    fi
   fi
   eval "${cmd}"
 }

--- a/bash_completion.d/_kill
+++ b/bash_completion.d/_kill
@@ -1,23 +1,26 @@
+#!/usr/bin/env bash
 __fzf_obc_post__kill() {
   local IFS=$'\n'
+  # shellcheck disable=SC2154
   case $prev in
     -s|-l)
       return 0
       ;;
   esac;
+  # shellcheck disable=SC2154
   if [[ $cword -eq 1 && "$cur" == -* ]]; then
     return 0
   else
     # Only surcharged if it is not an option
-    read -r -a COMPREPLY <<<"$(
+    read -r -d '' -a COMPREPLY < <(
       command ps -ef \
       | sed 1d \
-      | FZF_DEFAULT_OPTS="--height ${FZF_OBC_HEIGHT} --min-height 15 --reverse $FZF_DEFAULT_OPTS --preview 'echo {}' --preview-window down:3:wrap $FZF_COMPLETION_OPTS" \
-        __fzf_obc_cmd -m \
+      | FZF_DEFAULT_OPTS="--height ${FZF_OBC_HEIGHT} --min-height 15 --reverse $FZF_DEFAULT_OPTS --preview 'echo {}' --preview-window down:3:wrap $FZF_COMPLETION_OPTS -m" \
+        __fzf_obc_cmd \
       | awk '{print $2}' \
       | tr '\n' ' ' \
       | sed 's/ $//'
-    )"
+    )
     printf '\e[5n'
     return 0
   fi

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'ttytest'
+gem 'minitest'

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.11.3)
+    ttytest (0.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  minitest
+  ttytest
+
+BUNDLED WITH
+   1.16.1

--- a/test/lib/ttytest_addons.rb
+++ b/test/lib/ttytest_addons.rb
@@ -1,0 +1,98 @@
+module TTYtest
+  class << self
+    attr_accessor :debug
+    attr_accessor :pause
+    attr_accessor :send_keys_delay
+  end
+  self.debug = false
+  self.pause = false
+  self.send_keys_delay = 0.1
+
+  module Matchers
+    def assert_rows_include(expected)
+      expected = expected.rstrip
+      if !to_s.match(/^#{Regexp.quote(expected)}$/)
+        raise <<~HEREDOC
+          #{MatchError}
+          Was expecting to find:
+          #{expected}
+          In :
+          #{to_s}
+        HEREDOC
+      end
+    end
+
+    def assert_rows_count(operator,int)
+      nb_rows = rows.count { |s| s != "" }
+      if !nb_rows.send(operator,int)
+        raise <<~HEREDOC
+          #{MatchError}
+          Was expecting to see #{operator} #{int} none empty rows
+          But only #{nb_rows} none empty rows were found
+        HEREDOC
+      end
+    end
+    METHODS_TO_ADD = ['assert_rows_include','assert_rows_count']
+  end
+
+  class Terminal
+    def_delegators :@driver_terminal, :clear_screen
+    TTYtest::Matchers::METHODS_TO_ADD.each do |matcher_name|
+      define_method matcher_name do |*args|
+        synchronize do
+          capture.public_send(matcher_name, *args)
+        end
+      end
+    end
+  end
+
+  module Tmux
+    class Session
+      def send_keys(*keys)
+        keys.each do |key|
+          cmds = key.split("\n")
+          cmds.each do |item|
+            if TTYtest.debug and TTYtest.pause
+              printf "Press enter to send: " + item.dump
+              while ! gets
+                sleep 0.05
+              end
+            end
+            driver.tmux(*%W[send-keys -t #{name}], *item)
+            sleep TTYtest.send_keys_delay
+          end
+        end
+      end
+
+      def clear_screen
+        if TTYtest.debug and TTYtest.pause
+          printf 'Press enter will clear the screen'
+          while ! gets
+            sleep 0.05
+          end
+        end
+        driver.tmux(*%W[send-keys -Rt #{name}], 'Escape')
+        driver.tmux(*%W[send-keys -Rt #{name}], 'Escape')
+        driver.tmux(*%W[send-keys -Rt #{name}], 'C-c')
+        driver.tmux(*%W[send-keys -Rt #{name}], 'C-c')
+        driver.tmux(*%W[send-keys -Rt #{name}], 'Enter')
+        driver.tmux(*%W[send-keys -Rt #{name}], 'printf "\\033c"')
+        driver.tmux(*%W[send-keys -Rt #{name}], 'Enter')
+      end
+    end
+  end
+end
+
+def check_cmds(cmds)
+  if cmds.is_a? String
+    cmds = cmds.split(',')
+  end
+  for bin in cmds do
+    if ! find_executable "#{bin}"
+      raise "=====> Missing executable '#{bin}' <=====\n#{to_s}"
+      exit 1
+    end
+  end
+  puts "\nRequired binaries : OK\n\n"
+end
+

--- a/test/test-fzf-obc.rb
+++ b/test/test-fzf-obc.rb
@@ -1,0 +1,305 @@
+FILE = File.expand_path(__FILE__)
+BASE = File.expand_path('../../', __FILE__)
+TEST_DIR = "test/structure"
+HOME_TEST_DIR = ".local/tmp/fzf-obc/test/structure"
+Dir.chdir BASE
+
+DOWN='Down'
+UP='Up'
+LEFT='Left'
+RIGHT='Right'
+TAB='Tab'
+ENTER='Enter'
+ESCAPE='Escape'
+CTRLC='C-c'
+
+require 'minitest'
+require 'minitest/autorun'
+require 'ttytest'
+require_relative 'lib/ttytest_addons'
+require 'mkmf'
+
+puts "\nChecking for binaries required for those tests\n\n"
+
+check_cmds('fzf,git')
+
+
+class FzfObcTest < Minitest::Test
+
+  @@prepare_tmux_done = false
+
+  def setup
+    prepare_tmux
+    @@tty.clear_screen()
+  end
+
+  def teardown
+    if !TTYtest.debug
+      Dir.chdir BASE
+      FileUtils.rm_rf "#{TEST_DIR}"
+      FileUtils.rm_rf "#{ENV['HOME']}/#{HOME_TEST_DIR}"
+    end
+  end
+
+  def prepare_tmux
+    return if @@prepare_tmux_done
+    @@prepare_tmux_done = true
+
+    puts 'Preparing the environment for testing.......'
+
+    @@tty = TTYtest.new_terminal(<<~HEREDOC,width: 230)
+      env -i \
+        PS1='$ ' \
+        PATH="#{ENV['PATH']}" \
+        PROMPT_COMMAND='' \
+        TESTS_DEBUG="#{ENV['TESTS_DEBUG']}" \
+        TESTS_PAUSE="#{ENV['TESTS_PAUSE']}" \
+        TESTS_KEYS_DELAY="#{ENV['TESTS_KEYS_DELAY']}" \
+        HISTFILE='' \
+        FZF_OBC_HEIGHT='90%' \
+        FZF_OBC_OPTS="--select-1 --exit-0 --no-sort --no-mouse --bind 'ctrl-c:cancel'" \
+        FZF_OBC_GLOBS_OPTS="-m --select-1 --exit-0 --no-sort --no-mouse --bind 'ctrl-c:cancel'" \
+        /bin/bash --norc --noprofile
+    HEREDOC
+    sleep(1)
+
+    if ENV['TESTS_DEBUG']
+      TTYtest.debug = true
+    elsif ENV['TESTS_PAUSE']
+      TTYtest.debug = true
+      TTYtest.pause = true
+    end
+
+    if ENV['TESTS_KEYS_DELAY']
+      TTYtest.send_keys_delay = ENV['TESTS_KEYS_DELAY'].to_f
+    end
+
+    if TTYtest.debug
+      puts(<<~EOF)
+        ***************************
+        Debug session start
+        Please, open a new terminal and join the debug session with:
+        tmux -L ttytest attach
+        Then, come back here and press 'Enter' to start
+        To stop the debug session, press Ctrl+c
+        ***************************
+      EOF
+      while ! gets
+        sleep 0.1
+      end
+    end
+
+    @@tty.send_keys(<<~EOF)
+      source /etc/bash_completion; echo $?
+      #{ENTER}
+    EOF
+    @@tty.assert_matches(<<~EOF)
+      $ source /etc/bash_completion; echo $?
+      0
+      $
+    EOF
+    @@tty.clear_screen()
+
+    @@tty.max_wait_time = 3
+    @@tty.send_keys(<<~EOF)
+      source fzf-obc.bash; echo $?
+      #{ENTER}
+    EOF
+    @@tty.assert_matches(<<~EOF)
+      $ source fzf-obc.bash; echo $?
+      0
+      $
+    EOF
+    @@tty.clear_screen()
+
+    @@tty.max_wait_time = 2
+    @@tty.send_keys(<<~EOF)
+      complete | grep __fzf
+      #{ENTER}
+    EOF
+    @@tty.assert_rows_count(:>,2)
+    @@tty.assert_row(-1, '$')
+
+    puts 'Preparation finished !'
+    puts 'Starting tests..........'
+  end
+
+  def files_creation
+    (1..10).each do |idx|
+      FileUtils.mkdir_p "#{TEST_DIR}/d#{idx}"
+    end
+    FileUtils.mkdir_p "#{TEST_DIR}/d1 0"
+    FileUtils.touch "#{TEST_DIR}/xxx"
+    FileUtils.touch "#{TEST_DIR}/xxx xxx"
+    FileUtils.touch "#{TEST_DIR}/d10/xxx"
+    FileUtils.touch "#{TEST_DIR}/yyy"
+    FileUtils.touch "#{TEST_DIR}/d10/yyy yyy"
+  end
+
+  def files_glob_creation
+    files_creation
+  end
+
+  def files_home_completion
+    FileUtils.mkdir_p "#{ENV['HOME']}/#{HOME_TEST_DIR}"
+    FileUtils.touch "#{ENV['HOME']}/#{HOME_TEST_DIR}/fzf-obc.test"
+    FileUtils.touch "#{ENV['HOME']}/#{HOME_TEST_DIR}/test-fzf-obc.test"
+    FileUtils.touch "#{ENV['HOME']}/#{HOME_TEST_DIR}/test fzf-obc.test"
+  end
+
+  def files_home_glob_completion
+    files_home_completion
+  end
+
+  def test_files_completion
+    puts "\nDebug: inside " + __method__.to_s + "\n" if TTYtest.debug
+    files_creation
+    @@tty.send_keys(<<~EOF)
+      cat #{TEST_DIR}/
+      #{TAB}
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat #{TEST_DIR}/
+      >
+        14/14
+      > #{TEST_DIR}/yyy
+        #{TEST_DIR}/xxx xxx
+        #{TEST_DIR}/xxx
+        #{TEST_DIR}/d9/
+        #{TEST_DIR}/d8/
+        #{TEST_DIR}/d7/
+        #{TEST_DIR}/d6/
+        #{TEST_DIR}/d5/
+        #{TEST_DIR}/d4/
+        #{TEST_DIR}/d3/
+        #{TEST_DIR}/d2/
+        #{TEST_DIR}/d10/
+        #{TEST_DIR}/d1/
+        #{TEST_DIR}/d1 0/
+    TTY
+    @@tty.send_keys(<<~EOF)
+      x
+      #{TAB}
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat #{TEST_DIR}/xxx\\ xxx
+    TTY
+  end
+
+  def test_files_glob_completion
+    puts "\nDebug: inside " + __method__.to_s + "\n" if TTYtest.debug
+    files_glob_creation
+    @@tty.send_keys(<<~EOF)
+      cat #{TEST_DIR}/**
+      #{TAB}
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat #{TEST_DIR}/**
+      >
+        16/16
+      > #{TEST_DIR}/yyy
+        #{TEST_DIR}/xxx xxx
+        #{TEST_DIR}/xxx
+        #{TEST_DIR}/d9/
+        #{TEST_DIR}/d8/
+        #{TEST_DIR}/d7/
+        #{TEST_DIR}/d6/
+        #{TEST_DIR}/d5/
+        #{TEST_DIR}/d4/
+        #{TEST_DIR}/d3/
+        #{TEST_DIR}/d2/
+        #{TEST_DIR}/d10/yyy yyy
+        #{TEST_DIR}/d10/xxx
+        #{TEST_DIR}/d10/
+        #{TEST_DIR}/d1/
+        #{TEST_DIR}/d1 0/
+    TTY
+    @@tty.send_keys(<<~EOF)
+      x
+      #{TAB}
+      #{DOWN}
+      #{DOWN}
+      #{TAB}
+      #{ENTER}
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat #{TEST_DIR}/xxx\\ xxx #{TEST_DIR}/d10/xxx
+    TTY
+  end
+
+  def test_files_home_completion
+    puts "\nDebug: inside " + __method__.to_s + "\n" if TTYtest.debug
+    files_home_completion
+    @@tty.send_keys(<<~EOF)
+      cat ~/#{HOME_TEST_DIR}/
+      #{TAB}
+      'fzf-obc.test
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat ~/#{HOME_TEST_DIR}/
+      > 'fzf-obc.test
+        3/3
+      > ~/#{HOME_TEST_DIR}/test-fzf-obc.test
+        ~/#{HOME_TEST_DIR}/test fzf-obc.test
+        ~/#{HOME_TEST_DIR}/fzf-obc.test
+    TTY
+    @@tty.send_keys(<<~EOF)
+      #{CTRLC}
+      'test-fzf-obc.test
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat ~/#{HOME_TEST_DIR}/
+      > 'test-fzf-obc.test
+        1/3
+      > ~/#{HOME_TEST_DIR}/test-fzf-obc.test
+    TTY
+    @@tty.send_keys(<<~EOF)
+      #{CTRLC}
+      #{DOWN}
+      #{TAB}
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat ~/#{HOME_TEST_DIR}/test\\ fzf-obc.test
+    TTY
+  end
+
+  def test_files_home_glob_completion
+    puts "\nDebug: inside " + __method__.to_s + "\n" if TTYtest.debug
+    files_home_glob_completion
+    @@tty.send_keys(<<~EOF)
+      cat ~/#{HOME_TEST_DIR}/**
+      #{TAB}
+      'fzf-obc.test
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat ~/#{HOME_TEST_DIR}/**
+      > 'fzf-obc.test
+        3/3
+      > ~/#{HOME_TEST_DIR}/test-fzf-obc.test
+        ~/#{HOME_TEST_DIR}/test fzf-obc.test
+        ~/#{HOME_TEST_DIR}/fzf-obc.test
+    TTY
+    @@tty.send_keys(<<~EOF)
+      #{CTRLC}
+      'test-fzf-obc.test
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat ~/#{HOME_TEST_DIR}/**
+      > 'test-fzf-obc.test
+        1/3
+      > ~/#{HOME_TEST_DIR}/test-fzf-obc.test
+    TTY
+    @@tty.send_keys(<<~EOF)
+      #{CTRLC}
+      'fzf-obc.test
+      #{DOWN}
+      #{TAB}
+      #{TAB}
+      #{ENTER}
+    EOF
+    @@tty.assert_matches <<~TTY
+      $ cat ~/#{HOME_TEST_DIR}/test\\ fzf-obc.test ~/#{HOME_TEST_DIR}/fzf-obc.test
+    TTY
+  end
+
+end


### PR DESCRIPTION
- complete -F _minimal was not wrapped
- cleanup was not done as intended due to typo in variable name
- fix shellcheck errors
- fix search
- depending on os / bash version / config, compgen results was not in the same order and so the CI was not stable, so a sort function was add for this purpose and could be override by the user if needed
- add a beginning of CI tests to avoid regression ( need to add doc about them later and the purpose of TESTS_DEBUG , TESTS_PAUSE, TESTS_DELAY_KEYS  env running them )