### PR TITLE
Fix setup instructions in prerequisites.md

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -10,7 +10,7 @@
 $ brew install gnu-sed
 $ brew install coreutils
 $ brew install findutils
-$ echo "export PATH=$(brew --prefix gnu-sed)/bin:$(brew --prefix coreutils)/bin:$(brew --prefix findutils)/bin:$PATH" >> ~/.bash_profile
+$ echo "export PATH=$(brew --prefix gnu-sed)/gnubin:$(brew --prefix coreutils)/gnubin:$(brew --prefix findutils)/gnubin:\$PATH" >> ~/.bash_profile
 ```
 
 ## Bash

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -16,11 +16,13 @@ $ echo "export PATH=$(brew --prefix gnu-sed)/gnubin:$(brew --prefix coreutils)/g
 ## Bash
 
 - version \>= 4.0
+- bash completion \>= 2.0
 
 **MacOS user**
 
 ```
 $ brew install bash
+$ brew install bash-completion@2
 $ echo "export PATH=$(brew --prefix bash)/bin:$PATH" >> ~/.bash_profile
 $ sudo bash -c "echo $(brew --prefix)/bin/bash >> /private/etc/shells"
 $ chsh -s "$(brew --prefix bash)/bin/bash"


### PR DESCRIPTION
The `bin` directory under gnu tools holds binaries with prefix `g`, like `gsed`, `gfind`, etc.
If we want an override the dir to be added to path is `gbin`

Also I would suggest quoting `$PATH` when adding, but not expanding it -- I did appropriate change for that too.